### PR TITLE
event evt::yo_event_t::reportStateAll

### DIFF
--- a/yoRadio/src/core/evtloop.cpp
+++ b/yoRadio/src/core/evtloop.cpp
@@ -20,14 +20,14 @@
 static const char* TAG = "evt";
 
 ESP_EVENT_DEFINE_BASE(YO_CMD_EVENTS);
-ESP_EVENT_DEFINE_BASE(YO_GET_STATE_EVENTS);
+//ESP_EVENT_DEFINE_BASE(YO_GET_STATE_EVENTS);
 ESP_EVENT_DEFINE_BASE(YO_NTF_STATE_EVENTS);
 ESP_EVENT_DEFINE_BASE(YO_CHG_STATE_EVENTS);
 
 namespace evt {
 
-#define LOOP_EVT_Q_SIZE         8              // events loop queue size
-#define LOOP_EVT_PRIORITY       1              // task priority is same as arduino's loop() to avoid extra context switches
+#define LOOP_EVT_Q_SIZE         16             // events loop queue size
+#define LOOP_EVT_PRIORITY       2              // task priority is a bit higher than arduino's loop()
 #define LOOP_EVT_RUNNING_CORE   ARDUINO_RUNNING_CORE  //   tskNO_AFFINITY
 #ifdef YO_DEBUG_LEVEL
  #define LOOP_EVT_STACK_SIZE     5120           // task stack size

--- a/yoRadio/src/core/evtloop.h
+++ b/yoRadio/src/core/evtloop.h
@@ -16,7 +16,8 @@
 
 // ESP32 event loop defines
 ESP_EVENT_DECLARE_BASE(YO_CMD_EVENTS);          // declaration of Yo setter Command events (in reply to this command, an YO_CHG_EVENTS could be generated)
-ESP_EVENT_DECLARE_BASE(YO_GET_STATE_EVENTS);    // declaration of Yo "Get State" Command events - this is a request of some current states (in reply to this command, an YO_NTF_EVENTS could be generated)
+// not used for now, CMD_EVENT could be used for same
+//ESP_EVENT_DECLARE_BASE(YO_GET_STATE_EVENTS);    // declaration of Yo "Get State" Command events - this is a request of some current states (in reply to this command, an YO_NTF_EVENTS could be generated)
 ESP_EVENT_DECLARE_BASE(YO_NTF_STATE_EVENTS);    // declaration of Yo "Notify State" command events - this a current state reporting event (those events are published on request, not on change!!!)
 ESP_EVENT_DECLARE_BASE(YO_CHG_STATE_EVENTS);    // declaration of Yo "Change State" notification events base (those events are published when some state changes or in reply to "cmd set" events)
 
@@ -43,11 +44,13 @@ enum class yo_event_t:int32_t {
   brightness_lcurve,        // set brightness luma curve
   brightness_scale,         // set brightness scale
   brightness_step,          // step brightness incr/decr w/o fade, param: int n - step to shift
-  gradualFade,              // start gradual brightness fade, param gradual_fade_t
 
   // Device modes
   devMode = 30,             // set/notify about generic device mode changes, param - a member of yo_state enum. Dev modes has respective literal naming
 
+  // State reporting
+  reportStateAll,           // request state report from all componets
+  
   // Audio player
   // Audio player states
   playerStop = 100,         // player's state command/state, no param allowed

--- a/yoRadio/src/core/netserver.cpp
+++ b/yoRadio/src/core/netserver.cpp
@@ -83,6 +83,8 @@ void ui_page_radio(Interface *interf, JsonVariantConst data, const char* action)
   interf->json_section_uidata();
     interf->uidata_pick( "yo.pages.radio" );
   interf->json_frame_flush();
+  // request state reports, it should trigger sending WebUI updates for player state, screen brightness, etc...
+  EVT_POST(YO_CMD_EVENTS, e2int(evt::yo_event_t::reportStateAll));
 }
 
 // buld additional section under "Settings" page

--- a/yoRadio/src/displays/dspcore.h
+++ b/yoRadio/src/displays/dspcore.h
@@ -28,6 +28,9 @@ public:
   // low power mode enable/disable
   virtual void displaySuspend(bool state){ setBrightness( state ? 0 : brt); }
 
+protected:
+  virtual void embui_publish();
+
 private:
   // event function handlers
   esp_event_handler_instance_t _hdlr_cmd_evt{nullptr};

--- a/yoRadio/webresources/html/js/ui_yo.json
+++ b/yoRadio/webresources/html/js/ui_yo.json
@@ -128,7 +128,7 @@
         ]
       },
       {
-        "section":"callback",
+        "section":"callback___disabled",
         "block":[
           {"action": "player_getValues"}
         ]


### PR DESCRIPTION
используется для опроса статуса компонентов

 - реализована отправка данных звука/яркости в вебморду по событию на шине при формировании освновной странице
 - убран коллбек со сторны вебморды